### PR TITLE
Add left and right icon slots to ListItem, fix centring text inside …

### DIFF
--- a/docs/ListItem.md
+++ b/docs/ListItem.md
@@ -23,13 +23,15 @@ The `<kaiui-list-item>` component.
 
   The Tertiary Text 
 
-- `icon-left` ***String*** (*optional*) `default: 'none'` 
+- `icon-left` ***String*** (*optional*) `default: 'none'`
 
   The Left Icon CSS class 
+  ***Warning:*** Overrides `iconLeft` slot
 
-- `icon-right` ***String*** (*optional*) `default: 'kai-icon-arrow'` 
+- `icon-right` ***String*** (*optional*) `default: 'none'`
 
-  The Right Icon CSS class 
+  The Right Icon CSS class
+  ***Warning:*** Overrides `iconRight` slot
 
 ## events 
 
@@ -51,3 +53,13 @@ The `<kaiui-list-item>` component.
 
 - `set-element-selected` 
 
+## slots
+
+- `iconLeft`
+
+  Allows to use custom component/icon in left icon container
+  ***Warning:*** Not displayed if `iconLeft` prop is set and not `none`
+
+- `iconRight`
+  Allows to use custom component/icon in right icon container
+  ***Warning:*** Not displayed if `iconRight` prop is set and not `none`

--- a/src/components/ListItem.vue
+++ b/src/components/ListItem.vue
@@ -7,11 +7,9 @@
     v-on:blur="handleFocusChange(false)"
     v-on:click="onClick"
   >
-    <span
-      v-if="iconLeft && iconLeft != 'none'"
-      class="kaiui-listitem-icon"
-      v-bind:class="iconLeft"
-    ></span>
+    <span class="kaiui-listitem-icon" v-bind:class="iconLeft" v-if="$slots.iconLeft || hasLeftIcon">
+        <slot name="iconLeft" v-if="!hasLeftIcon"></slot>
+    </span>
     <div class="kaiui-listitem-text-wrapper">
       <span class="kaiui-p_pri kaiui-listitem-primary-text">{{
         primaryText
@@ -23,11 +21,9 @@
         tertiaryText
       }}</span>
     </div>
-    <span
-      v-if="iconRight && iconRight != 'none'"
-      class="kaiui-listitem-icon right"
-      v-bind:class="iconRight"
-    ></span>
+    <span class="kaiui-listitem-icon right" v-bind:class="iconRight" v-if="$slots.iconRight || hasRightIcon">
+        <slot name="iconRight" v-if="!hasRightIcon"></slot>
+    </span>
   </div>
 </template>
 
@@ -85,7 +81,7 @@ export default {
      * The Right Icon CSS class
      */
     iconRight: {
-      default: "kai-icon-arrow",
+      default: "none",
       type: String,
       required: false,
     },
@@ -110,7 +106,14 @@ export default {
       this.$emit("softCenter");
     });
   },
-
+  computed: {
+    hasLeftIcon() {
+      return this.iconLeft && this.iconLeft != 'none';
+    },
+    hasRightIcon() {
+      return this.iconRight && this.iconRight != 'none';
+    },
+  },
   methods: {
     /**
      * @private
@@ -163,7 +166,6 @@ export default {
   display: flex;
   flex-direction: column;
   justify-content: center;
-  height: 100%;
   overflow: hidden;
   flex: 1;
 }
@@ -183,10 +185,10 @@ export default {
 .kaiui-listitem[nav-selected="true"] .kaiui-listitem-tertiary-text {
   color: var(--listitem-selected-text-color);
 }
-.kaiui-listitem[nav-selected="true"] .kaiui-listitem-icon:before {
+.kaiui-listitem[nav-selected="true"] .kaiui-listitem-icon {
   color: var(--listitem-selected-text-color);
 }
-.kaiui-listitem[nav-selected="true"] .kaiui-listitem-icon.right:before {
+.kaiui-listitem[nav-selected="true"] .kaiui-listitem-icon.right {
   color: var(--listitem-selected-text-color);
 }
 
@@ -204,7 +206,7 @@ export default {
   flex-shrink: 0;
   margin-left: 10px;
 }
-.kaiui-listitem .kaiui-listitem-icon.right:before {
+.kaiui-listitem .kaiui-listitem-icon.right {
   color: var(--listitem-icon-right-color);
 }
 </style>


### PR DESCRIPTION
Motivation to do the fix is to allow using custom components/icons (for instance svg illustrations) in place of left and right icon via vue slots, while maintaining backward compatibility.
Changes  include
1) introducing _iconLeft_ and _iconRight_, both are displayed only if iconLeft/iconRight props are not specified.
2) removed `height: 100%` from text-wrapper. According to styles, text is supposed to be centred vertically, which didn't happen if this style was applied (see screenshots before and after fix)
<img width="353" alt="Screenshot 2021-04-06 at 15 22 41" src="https://user-images.githubusercontent.com/2708524/113720658-29594b00-96ef-11eb-9083-46d6dd0bfee1.png">
<img width="705" alt="Screenshot 2021-04-06 at 15 22 53" src="https://user-images.githubusercontent.com/2708524/113720664-29f1e180-96ef-11eb-8b00-a6371adea7d5.png">

3) removed default kai-icon-arrow from `iconRight` prop since I was not able to find it and it was not displayed anyway in the layout, however interferes with 1)
4) removed `:before` pseudo-class from icon color styles to allow drill `currentColor` down to slot elements to use it there 

Below there're screenshots from testing this component in different configurations:
<img width="698" alt="Screenshot 2021-04-06 at 15 25 36" src="https://user-images.githubusercontent.com/2708524/113720756-40983880-96ef-11eb-9a38-ca8722fad0ef.png">
<img width="698" alt="Screenshot 2021-04-06 at 15 25 44" src="https://user-images.githubusercontent.com/2708524/113720764-41c96580-96ef-11eb-9d0c-146c8d321baa.png">
<img width="697" alt="Screenshot 2021-04-06 at 15 25 51" src="https://user-images.githubusercontent.com/2708524/113720768-4261fc00-96ef-11eb-82aa-e738538ff658.png">
