### PR TITLE
Expose Navigation methods

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -22,6 +22,8 @@ import Notice from "./components/Notice.vue";
 import ToastMixin from "./mixins/Toast.mixin.vue";
 import NoticeMixin from "./mixins/Notice.mixin.vue";
 
+import Navigation from './navigation/Navigation';
+
 // CSS & Ionicons icons
 require("./assets/css/theme.css");
 require("./assets/ionicons/css/style.css");
@@ -70,4 +72,5 @@ if (GlobalVue) {
   GlobalVue.use(plugin);
 }
 
+export const Navigation = Navigation;
 export default plugin;


### PR DESCRIPTION
I'd like to expose all the navigation methods to the user, reasoning for this is that quite often you end up in a scenario where rendering of items is delayed, due to them coming from an external API. Currently the initial selection of the first `nav-selectable` element is done on mount.

I'm not sure if exposing all navigation methods is the preferred way. Another option is to build a mixin, which exposes at least the `initElements` method.